### PR TITLE
API定義書の修正

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11,7 +11,6 @@ servers:
   - url: http://localhost:8080
 
 # TODO: GETの絞り込み条件を追記する
-# TODO: /add_tagエンドポイントのクエリをボディに
 paths:
   /register_user:
     post:
@@ -306,7 +305,7 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequestResponse"
 
-  /add_tag/{bgmId}:
+  /add_tag:
     post:
       summary: 指定したBGMにタグを追加
       tags: [tag]
@@ -314,12 +313,6 @@ paths:
         - firebase: []
       x-roles:
         - USER
-      parameters:
-        - name: bgmId
-          in: path
-          required: true
-          schema:
-            type: integer
       requestBody:
         required: true
         content:
@@ -683,8 +676,12 @@ components:
     TagAddRequest:
       type: object
       required:
+        - bgmId
         - title
       properties:
+        bgmId:
+          type: integer
+          example: 123
         title:
           type: string
           example: "happy"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -716,10 +716,7 @@ components:
         id:
           type: integer
           example: 4
-        bgmId:
-          type: integer
-          example: 123
-        userId:
+        reporterId:
           type: string
           example: 8
         reason:
@@ -728,6 +725,19 @@ components:
         createdAt:
           type: string
           format: date-time
+        bgmId:
+          type: integer
+          example: 123
+        bgmAuthorId:
+          type: integer
+          example: 22
+        handlingNote:
+          type: string
+          example: BGMを削除して対応。また、ユーザーの他の投稿は問題ないため、今回BANはせず。
+        handledAt:
+          type: string
+          format: date-time
+      
 
     TagResponse:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -717,7 +717,7 @@ components:
           type: integer
           example: 4
         reporterId:
-          type: string
+          type: integer
           example: 8
         reason:
           type: string
@@ -737,7 +737,6 @@ components:
         handledAt:
           type: string
           format: date-time
-      
 
     TagResponse:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -10,7 +10,6 @@ info:
 servers:
   - url: http://localhost:8080
 
-# TODO: dataの命名を考える
 # TODO: GETの絞り込み条件を追記する
 # TODO: /add_tagエンドポイントのクエリをボディに
 paths:
@@ -190,7 +189,11 @@ paths:
                   isSuccess:
                     type: boolean
                   data:
-                    $ref: "#/components/schemas/BgmResponse"
+                    type: object
+                    properties:
+                      bgm:
+                        type: object
+                        $ref: "#/components/schemas/BgmResponse"
         "400":
           $ref: "#/components/responses/BadRequestResponse"
         "404":

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -591,7 +591,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundResponse"
 
-  /update_report/{reportId}:
+  /update_report:
     patch:
       summary: 違反報告への対応内容を記録する【管理者のみ】★
       tags: [report]
@@ -599,12 +599,6 @@ paths:
         - firebase: []
       x-roles:
         - ADMIN
-      parameters:
-        - name: reportId
-          in: path
-          required: true
-          schema:
-            type: integer
       requestBody:
         required: true
         content:
@@ -654,8 +648,12 @@ components:
     ReportHandlingRequest:
       type: object
       required:
+        - reportId
         - handlingNote
       properties:
+        reportId:
+          type: integer
+          example: 4
         handlingNote:
           type: string
           example: 投稿が悪質なため、BGMを削除した

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -10,7 +10,6 @@ info:
 servers:
   - url: http://localhost:8080
 
-# TODO: GETの絞り込み条件を追記する
 paths:
   /register_user:
     post:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -591,7 +591,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundResponse"
 
-  /update_report:
+  /add_handling_note:
     patch:
       summary: 違反報告への対応内容を記録する【管理者のみ】★
       tags: [report]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -43,7 +43,7 @@ paths:
 
   /get_bgm_list:
     get:
-      summary: BGM一覧を取得(タグ検索)
+      summary: BGM一覧を取得(クエリでタグ検索も可)
       description: 並び順は投稿日の新しい順。
       tags: [bgm]
       parameters:
@@ -104,7 +104,70 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequestResponse"
 
-  /get_bgm_list/{userId}:
+  /get_bgm_list/tag_id/{tagId}:
+    get:
+      summary: 指定したタグIDと紐づくBGM一覧を取得
+      description: 並び順は投稿日の新しい順。
+      tags: [bgm]
+      parameters:
+        - name: tagId
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: ページ番号(1始まり)
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: size
+          in: query
+          description: 1ページあたりの取得件数
+          required: false
+          schema:
+            type: integer
+            default: 30
+      responses:
+        "200":
+          description: BGM一覧を取得しました
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      bgmList:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BgmResponse"
+                      page:
+                        type: integer
+                        example: 1
+                      size:
+                        type: integer
+                        example: 30
+                      totalItems:
+                        type: integer
+                        example: 150
+                      totalPages:
+                        type: integer
+                        example: 5
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+
+  /get_bgm_list/user_id/{userId}:
     get:
       summary: 指定したユーザーが投稿したBGM一覧を取得
       description: 並び順は投稿日の新しい順。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11,7 +11,6 @@ servers:
   - url: http://localhost:8080
 
 # TODO: dataの命名を考える
-# TODO: テーブルという表現は誤りのためレコードに修正
 # TODO: GETの絞り込み条件を追記する
 # TODO: /add_tagエンドポイントのクエリをボディに
 paths:
@@ -21,7 +20,7 @@ paths:
       tags: [auth]
       description: |
         - ユーザーがFirebaseでログインした後、初回だけ呼び出される
-        - ID Tokenを検証し、該当するユーザーが存在しなければUserテーブルを作成しIDを返却、存在すればIDだけ返却
+        - ID Tokenを検証し、該当するユーザーが存在しなければUserテーブルにレコードを作成しIDを返却、存在すればIDだけ返却
           - 別端末の同Googleアカウントからのログインなどの可能性
         - 投稿者データ(userId)はJWTトークンからサーバ側で判別するため、リクエストボディには含めない
       security:
@@ -227,7 +226,7 @@ paths:
     patch:
       summary: 指定したBGMを論理削除【投稿ユーザと管理者のみ】★
       description: |
-        BGMテーブルのisDeletedフラグをtrueにし、BGMのidと紐づくBgmTagテーブルを削除する（タグは全BGMで共通して使用するので、Tagテーブルはそのまま）。
+        BGMテーブルの該当レコードのisDeletedフラグをtrueにし、BGMのidと紐づくBgmTagテーブルのレコードを削除する（タグは全BGMで共通して使用するので、Tagテーブルのレコードはそのまま）。
       tags: [bgm]
       security:
         - firebase: []


### PR DESCRIPTION
## 修正内容

- 「テーブル」という言葉の使い方の修正
- レスポンスボディのデータ構造を修正
	- `/get_xxxx_list`エンドポイントでは、`data`オブジェクト内部に`bgmList`や`tagList`、`bookmarkList`といった配列で各種データを返却していたが、`/get_bgm`だけが直接`data`オブジェクトにBGMのデータを渡している状況だった
	- これを、`data.bgm.id`のように、リスト系のレスポンスと同じような方法でフロントで取得できるよう、修正
- `/add_tag/{bgmId}`のBGM ID指定を、ボディ内で行うよう修正
- `/update_report/{reportId}`のレポートID指定を、ボディ内で行うよう修正
-  `/update_report`を`/add_handling_note`に命名変更
- `/get_report_list`で得られる項目を追加

## 通報フローについて
以下、こちらで考えているフロントエンドの実装になります：
![IMG_2173](https://github.com/user-attachments/assets/7516e284-0714-4db2-b71d-5dc213765c10)
- 通報フローは[こちら](https://github.com/kagomen/bgm-api-springboot/blob/main/docs/flowchart.md) 
- BANやBGMの削除は管理者の判断で行い、対応が終わったら対応内容を記録するといった流れになるため、`/ban_user/{userId}`では、対応内容を記述するボディを設ける必要がないと考えますが、何か他に考慮漏れ等ありますでしょうか？

## あとでやること

#3  のマージ後に以下の修正を行う

- タグ検索エンドポイントで、タグ名ではなくタグIDを指定するよう修正
- GET系操作の条件を追記・修正する